### PR TITLE
When trying to extract user quota info from the headers, do not try to join

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -60,7 +60,7 @@ class RGWAdmin:
             log.exception(e)
             return None
         try:
-            j = json.load(StringIO(":".join(list(r.headers.items())[1]).split("Status")[0] if "quota" in url else r.content))
+            j = json.load(StringIO(":".join(list(r.headers.items()[3])).split("Status")[0] if "quota" in url else r.content))
         except ValueError as e:
             log.info(e)
             j = None


### PR DESCRIPTION
the headers unrelated to the quota information.  Otherwise, you will get
an error when trying to join something that is not a list.
