### PR TITLE
Get all buckets.

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -322,6 +322,10 @@ class RGWAdmin:
         return self.request('delete', '/%s/user?key&format=%s&%s' %
                             (self._admin, self._response, parameters))
 
+    def get_buckets(self):
+        return self.request('get', '/%s/metadata/bucket?format=%s' %
+                            (self._admin, self._response))
+
     def get_bucket(self, bucket=None, uid=None, stats=False):
         parameters = ''
         if bucket is not None:


### PR DESCRIPTION
This adds a new `get_buckets()` method, similar to `get_users()`, which fetch all bucket IDs via a call on metadata endpoint.