### PR TITLE
Fix KeyError

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -100,7 +100,7 @@ class RGWAdmin:
         else:
             if j is not None:
                 log.error(j)
-                code = str(j['Code'])
+                code = str(j.get('Code', 'InternalError'))
             else:
                 raise ServerDown
             for e in [AccessDenied, UserExists, InvalidAccessKey,


### PR DESCRIPTION
Hi,

This PR fixes `KeyError` when we don't have the field `Code`

```
  File "/Users/quentinperez/.virtualenvs/.../lib/python2.7/site-packages/rgwadmin/rgw.py", line 103, in _load_request
    code = str(j['Code'])
KeyError: 'Code'
```