### PR TITLE
add timeout for requests

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -34,7 +34,7 @@ class RGWAdmin:
 
     def __init__(self, access_key, secret_key, server,
                  admin='admin', response='json', ca_bundle=None,
-                 secure=True, verify=True):
+                 secure=True, verify=True, timeout=None):
         self._access_key = access_key
         self._secret_key = secret_key
         self._server = server
@@ -48,6 +48,8 @@ class RGWAdmin:
             self._protocol = 'https'
         else:
             self._protocol = 'http'
+
+        self._timeout = timeout
 
     @classmethod
     def connect(cls, **kwargs):
@@ -134,7 +136,8 @@ class RGWAdmin:
             else:
                 verify = self._verify
             auth = S3Auth(self._access_key, self._secret_key, self._server)
-            r = m(url, headers=headers, auth=auth, verify=verify, data=data)
+            r = m(url, headers=headers, auth=auth, verify=verify, data=data,
+                  timeout=self._timeout)
         except Exception as e:
             log.exception(e)
             raise


### PR DESCRIPTION
Currently requests have no timeout (by default in requests lib). Hanged RGWs may keep REST API tasks running unnecessarily long. Adding timeout prevents such situations.