### PR TITLE
Removed RGWAdmin.create_bucket

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -443,9 +443,6 @@ class RGWAdmin:
         return self.request('get', '/%s/bucket?index&format=%s&%s' %
                             (self._admin, self._response, parameters))
 
-    def create_bucket(self, bucket):
-        return self.request('put', '/%s' % bucket)
-
     def remove_bucket(self, bucket, purge_objects=False):
         parameters = 'bucket=%s' % bucket
         parameters += '&purge-objects=%s' % purge_objects

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+def create_bucket(rgw, bucket=None):
+    """
+    This is a helper function for tests to create buckets so they can assert changes
+    on the gateway based on the bucket's existence.
+
+    NOTE: The PUT /:bucket endpoint is not part of the Admin Ops API, and therefore
+    is not included in the rgw class.  The response format does not match other
+    Admin Operations, and it is largely incompatible with the rgw class.
+    """
+    return rgw.request('put', '/%s' % bucket)

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -7,6 +7,7 @@ import unittest
 import rgwadmin
 from rgwadmin.compat import quote
 from rgwadmin.utils import get_environment_creds, id_generator
+from . import create_bucket
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -21,14 +22,14 @@ class MetadataTest(unittest.TestCase):
     def test_get_metadata(self):
         bucket_name = id_generator()
         self.assertTrue(bucket_name not in self.rgw.get_metadata('bucket'))
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
         self.assertTrue(bucket_name in self.rgw.get_metadata('bucket'))
         self.rgw.remove_bucket(bucket=bucket_name, purge_objects=True)
 
     def test_put_metadata(self):
         bucket_name = id_generator()
         self.assertTrue(bucket_name not in self.rgw.get_metadata('bucket'))
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
 
         ret_json = self.rgw.get_metadata('bucket', key=bucket_name)
         self.assertEqual(ret_json['data']['bucket']['name'], bucket_name)
@@ -39,7 +40,7 @@ class MetadataTest(unittest.TestCase):
 
     def test_metadata_lock_unlock(self):
         bucket_name = id_generator()
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
         self.rgw.lock_metadata('bucket', key=bucket_name, lock_id='abc',
                                length=5)
         self.rgw.unlock_metadata('bucket', key=bucket_name, lock_id='abc')
@@ -56,7 +57,7 @@ class MetadataTest(unittest.TestCase):
 
     def test_get_bucket_instances(self):
         bucket_name = id_generator()
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
         instances = self.rgw.get_bucket_instances()
         bucket = self.rgw.get_bucket(bucket_name)
         expected_instance = '%s:%s' % (bucket_name, bucket['id'])

--- a/test/test_rgw.py
+++ b/test/test_rgw.py
@@ -6,6 +6,7 @@ import unittest
 import random
 from rgwadmin.exceptions import InvalidArgument
 from rgwadmin.utils import get_environment_creds
+from . import create_bucket
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -83,7 +84,7 @@ class RGWAdminTest(unittest.TestCase):
     def test_bucket_quota(self):
         size = random.randint(1000, 1000000)
         bucket_name = self.user1 + '_bucket'
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
         self.rgw.set_bucket_quota(uid=self.user1, bucket=bucket_name,
                                   max_size_kb=size, enabled=True)
         bucket = self.rgw.get_bucket(bucket=bucket_name)
@@ -91,7 +92,7 @@ class RGWAdminTest(unittest.TestCase):
 
     def test_bucket(self):
         bucket_name = self.user1 + '_bucket'
-        self.rgw.create_bucket(bucket=bucket_name)
+        create_bucket(self.rgw, bucket=bucket_name)
         bucket = self.rgw.get_bucket(bucket=bucket_name)
         self.rgw.link_bucket(bucket=bucket_name, bucket_id=bucket['id'],
                              uid=self.user1)


### PR DESCRIPTION
Closes #33 and #27

The `create_bucket` function called an endpoint that wasn't part of the
Admin Ops API, and whose output was incompatible with the rest of this
library as a result.  This caused any error coming back from
`create_bucket` to raise a `ServerDown`.  After some discussion in #33,
it was agreed upon that removing the feature was the best approach.

Removing this wasn't as clean as it could've been, as tests relied on it
in a few places.  I replicated the function in the test module for use
during unit tests, so as to not disrupt what the tests were already
doing.  I'm not sure this was the right approach - feedback is welcome.

**This is a breaking change**.

I did not run the test suite as I don't have access to a gateway to run
it against at present.