### PR TITLE
Allow modifying users while they're suspended

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -279,7 +279,7 @@ class RGWAdmin:
 
     def modify_user(self, uid, display_name=None, email=None, key_type='s3',
                     access_key=None, secret_key=None, user_caps=None,
-                    generate_key=False, max_buckets=None, suspended=False):
+                    generate_key=False, max_buckets=None, suspended=None):
         parameters = 'uid=%s' % uid
         if display_name is not None:
             parameters += '&display-name=%s' % display_name
@@ -296,7 +296,8 @@ class RGWAdmin:
         parameters += '&generate-key=%s' % generate_key
         if max_buckets is not None:
             parameters += '&max-buckets=%s' % max_buckets
-        parameters += '&suspended=%s' % suspended
+        if suspended is not None:
+            parameters += '&suspended=%s' % suspended
         return self.request('post', '/%s/user?format=%s&%s' %
                             (self._admin, self._response, parameters))
 

--- a/test/test_rgw.py
+++ b/test/test_rgw.py
@@ -51,6 +51,21 @@ class RGWAdminTest(unittest.TestCase):
         self.assertNotEqual(before_keys, user['keys'])
         self.assertEqual(len(before_keys) + 1, len(user['keys']))
 
+        # modifying a user doesn't automatically un-suspend them
+        # setup - suspend them first
+        user = self.rgw.modify_user(uid=self.user1, suspended=True)
+        self.assertEqual(user['suspended'], 1)
+
+        # test - modify their username without unsuspending them
+        user = self.rgw.modify_user(uid=self.user1,
+                                    email='%s@test2.com' % self.user1)
+        self.assertTrue(user['email'] == '%s@test2.com' % self.user1)
+        self.assertEqual(user['suspended'], 1)
+
+        # unsuspend the user to allow other tests to function
+        user = self.rgw.modify_user(uid=self.user1, suspended=False)
+        self.assertEqual(user['suspended'], 0)
+
     def test_duplicate_email(self):
         with self.assertRaises(InvalidArgument):
             self.rgw.create_user(uid=self.user3,


### PR DESCRIPTION
This behavior was introduced in the [initial commit](https://github.com/UMIACS/rgwadmin/commit/b590173f72f944060e218d0575cd5c7edca87940#diff-982b1bd760fd4fdfe121c95c5d5515b7R66)
without explanation, and is unexpected; Ceph allows modifying users
while they're suspended, so I don't see a reason to unsuspend users by
default when modifying them.  In practice, this means that client code
needs to look up the current suspended status of a user before modifying
them, which is easy to miss.

This is a breaking change, and if someone's implementation depends on
this behavior it could cause them problems; I'm working around it now,
and will continue to if this isn't something worth changing.