### PR TITLE
Pool Connections in RGWAdmin Client

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -36,7 +36,7 @@ class RGWAdmin:
 
     def __init__(self, access_key, secret_key, server,
                  admin='admin', response='json', ca_bundle=None,
-                 secure=True, verify=True, timeout=None, pool_connections=True):
+                 secure=True, verify=True, timeout=None, pool_connections=False):
         self._access_key = access_key
         self._secret_key = secret_key
         self._server = server


### PR DESCRIPTION
It's common in my usage to create an RGWAdmin instance and use it for
multiple requests.  As implemented now, this requires creating a new
connection per request, which isn't horribly slow but it's not as fast
as keeping the TCP connection open.

This change uses a `requests.Session` to keep the TCP connection open so
that multiple requests being made to the same endpoint don't have to
renegotiate the connection.  This results in a small, but appreciable speed
improvement.

I tested the difference by making a client with pooling enabled and one
without and hitting the same admin endpoint 100 times in a loop, timing
the entire operation.  The results were:

No pooling: ~19s
Pooling: ~6s

I made this configurable - it's enabled by default since I assume
this is the common usage pattern, but it can be disabled and fall back
to the old behavior.