### PR TITLE
Add type hints

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,14 @@
 stages:
+  - test
   - build
   - deploy
+
+mypy:
+  stage: test
+  image: python:3.6-slim
+  script:
+    - pip install -q tox
+    - tox -e mypy
 
 build_python_package:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,8 +7,8 @@ mypy:
   stage: test
   image: python:3.6-slim
   script:
-    - pip install -q tox
-    - tox -e mypy
+    - pip install -q mypy
+    - mypy rgwadmin/
 
 build_python_package:
   stage: build

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-awsauth]
+ignore_missing_imports = True

--- a/rgwadmin/py.typed
+++ b/rgwadmin/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The rgwadmin package uses inline types.

--- a/rgwadmin/user.py
+++ b/rgwadmin/user.py
@@ -1,6 +1,8 @@
 import logging
 from collections import OrderedDict
 
+from typing import List
+
 from .utils import random_password
 from .rgw import RGWAdmin
 from .exceptions import NoSuchKey
@@ -9,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class AttributeMixin(object):
-    attrs = []
+    attrs: List[str] = []
 
     def __str__(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ with open('rgwadmin/__init__.py', encoding='utf-8') as f:
 setup(
     name="rgwadmin",
     packages=["rgwadmin"],
+    package_data={"rgwadmin": ["py.typed"]},
+    zip_safe=False,
     version=version,
     install_requires=install_requires,
     author="Derek Yarnell",


### PR DESCRIPTION
This PR adds type hints to rgwadmin.

One questions I had was how to reference the types for qav and have them be recognized.  Do we need to include type stubs as package data?  https://mypy.readthedocs.io/en/latest/installed_packages.html#installed-packages