### PR TITLE
always pass generate_secret in create_subuser

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -392,8 +392,7 @@ class RGWAdmin:
             parameters += '&key-type=%s' % key_type
         if access is not None:
             parameters += '&access=%s' % access
-        if generate_secret:
-            parameters += '&generate-secret=%s' % generate_secret
+        parameters += '&generate-secret=%s' % generate_secret
         return self.request('put', '/%s/user?subuser&format=%s&%s' %
                             (self._admin, self._response, parameters))
 


### PR DESCRIPTION
Setting `generate_secret` to `False` results in the query param not being populated. It looks like the convention here is to just always pass boolean fields, so that's what I did.

Also went through the rest of the methods but didn't see any other arguments with default booleans that were incorrectly `if`'d.