### PR TITLE
new: add access_key kwarg to get_user

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -241,9 +241,17 @@ class RGWAdmin:
             params=params,
         )
 
-    def get_user(self, uid: str, stats=False):
-        return self.request('get', '/%s/user?format=%s&uid=%s&stats=%s' %
-                            (self._admin, self._response, uid, stats))
+    def get_user(self, uid: str = None, access_key: str = None, stats=False):
+        if uid is not None and access_key is not None:
+            raise ValueError('Only one of uid and access_key is allowed')
+        parameters = ''
+        if uid is not None:
+            parameters += '&uid=%s' % uid
+        if access_key is not None:
+            parameters += '&access-key=%s' % access_key
+        parameters += '&stats=%s' % stats
+        return self.request('get', '/%s/user?format=%s%s' %
+                            (self._admin, self._response, parameters))
 
     def get_users(self):
         return self.get_metadata(metadata_type='user')


### PR DESCRIPTION
Although this is undocumented, it does exist in the code:

https://github.com/ceph/ceph/blob/v15.2.8/src/rgw/rgw_rest_user.cc#L70

And worked on my ceph cluster.

I'll note in my testing `access_key` overrode `uid`, which feels unintuitive to me, so personally I think it makes sense to prevent the user from passing both. Passing neither will return a `400 Invalid Argument` from ceph.