### PR TITLE
Add host request header

### DIFF
--- a/rgwadmin/rgw.py
+++ b/rgwadmin/rgw.py
@@ -142,6 +142,12 @@ class RGWAdmin:
 
     def request(self, method, request, headers: Optional[Dict] = None, data=None):
         url = '%s%s' % (self.get_base_url(), request)
+        # add host request header
+        if headers:
+            headers['host'] = self._server
+        else:
+            headers = {'host': self._server}
+        
         log.debug('URL: %s' % url)
         log.debug('Access Key: %s' % self._access_key)
         log.debug('Verify: %s  CA Bundle: %s' % (self._verify,


### PR DESCRIPTION
Because the port number is not included in the host request header, the requests-aws4auth revert commit computes the wrong signature starting with version 1.2.2. If RGW does not utilize port 80 or 433, the signature will be incorrect. So I included host header request for requests-aws4auth computes right signature.

Ref and issues:
https://github.com/tedder/requests-aws4auth/issues/34
https://github.com/tedder/requests-aws4auth/commit/b328b86b68dc0cb92add0ca0e47ad997cd65d405
https://github.com/tedder/requests-aws4auth/commit/8e1417c3af7239ec42deb2d786ee082076a3d137
https://github.com/tedder/requests-aws4auth/issues/65